### PR TITLE
Update CPython version and SIP build configuration

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
-version: "5.11.0"
+version: "5.12.0-alpha.0"
 requirements:
   - "arcus/5.11.0"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,3 +1,3 @@
-version: "5.12.0-alpha.0"
+version: "5.11.2-alpha.0"
 requirements:
-  - "arcus/5.11.0"
+  - "arcus/5.11.1"

--- a/conanfile.py
+++ b/conanfile.py
@@ -72,7 +72,7 @@ class ArcusConan(ConanFile):
     def requirements(self):
         for req in self.conan_data["requirements"]:
             self.requires(req)
-        self.requires("cpython/3.12.2")
+        self.requires("cpython/3.12.7")
 
     def validate(self):
         if self.settings.compiler.cppstd:
@@ -120,7 +120,9 @@ class ArcusConan(ConanFile):
 
         # Generate the Source code from SIP
         sip = self.python_requires["sipbuildtool"].module.SipBuildTool(self)
-        sip.configure()
+        # Use the full path to sip-build from the CPython Scripts directory
+        sip_build_path = os.path.join(self.dependencies["cpython"].cpp_info.bindirs[0], "Scripts", "sip-build.exe")
+        sip.configure(sip_install_executable=sip_build_path)
         sip.build()
 
     def layout(self):

--- a/conanfile.py
+++ b/conanfile.py
@@ -120,9 +120,8 @@ class ArcusConan(ConanFile):
 
         # Generate the Source code from SIP
         sip = self.python_requires["sipbuildtool"].module.SipBuildTool(self)
-        # Use the full path to sip-build from the CPython Scripts directory
-        sip_build_path = os.path.join(self.dependencies["cpython"].cpp_info.bindirs[0], "Scripts", "sip-build.exe")
-        sip.configure(sip_install_executable=sip_build_path)
+        # Auto-detect sip-build from CPython dependency (cross-platform)
+        sip.configure(cpython_dependency=self.dependencies["cpython"])
         sip.build()
 
     def layout(self):


### PR DESCRIPTION
Bumps CPython dependency from 3.12.2 to 3.12.7 and modifies SIP build tool configuration to use the full path to sip-build from the CPython Scripts directory for improved reliability.
Requires:
https://github.com/Ultimaker/conan-ultimaker-index/pull/25

CURA-12814